### PR TITLE
Add Statamic 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "visuellverstehen/statamic-content-renderer",
     "description": "A Statamic search transformer for bard and replicator fields.",
-    "keywords": [ "statamic", "addon", "bard", "replicator", "search", "content", "fulltext", "v3", "v4" ],
+    "keywords": [ "statamic", "addon", "bard", "replicator", "search", "content", "fulltext", "v3", "v4", "v5", "v6" ],
     "license": "MIT",
     "type": "statamic-addon",
     "autoload": {
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": "^8.1",
-        "statamic/cms": "^3.4 || ^4.0 || ^5.0"
+        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Summary

Adds Statamic 6 to the supported versions constraint in `composer.json`.

## Changes

- `composer.json`: extended `statamic/cms` requirement from `^3.4 || ^4.0 || ^5.0` to `^3.4 || ^4.0 || ^5.0 || ^6.0`
- `composer.json`: added `v5` and `v6` to keywords

## Testing

Verified working on a Statamic 6 project — the package installs and functions without any code changes. No PHP source modifications were needed; the package is fully compatible with Statamic 6 as-is.